### PR TITLE
Switch to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,5 +30,5 @@ pytest-black = "^0.3.12"
 pytest = "^6.2.2"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
`poetry-core` is intended to be a lightweight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects.